### PR TITLE
feat(wsl2): harden dokploy swarm installer with tls and port rebind

### DIFF
--- a/docs/windows-wsl2.md
+++ b/docs/windows-wsl2.md
@@ -8,53 +8,79 @@ WSL while exposing HTTP/HTTPS and admin ports on the Windows host.
 
 1. Enable **WSL2** and install a Linux distribution (Ubuntu 22.04 is the default).
    Refer to Microsoft’s documentation for enabling WSL on Windows Server 2022.
-2. Install **Docker** in your WSL distribution.  Docker Desktop is not
-   necessary; you can install the Docker engine inside WSL and run it via
+2. Ensure the distribution starts with **systemd** enabled (set `[boot] systemd=true`
+   in `/etc/wsl.conf` and restart WSL if needed).
+3. Install **Docker** in your WSL distribution.  Docker Desktop is not
+   necessary; install the Docker engine inside WSL and manage it with
    `systemd`.
-3. Run PowerShell as an administrator when executing scripts.
+4. Run PowerShell as an administrator when executing scripts.
 
 ## Installation
 
 Use the provided PowerShell script to install Dokploy and Traefik inside WSL and
 set up port forwarding.  The script will:
 
-* Verify that you are running as an administrator and that WSL and Docker are
-  available.
-* Start Docker via `systemd` in the WSL distribution.
-* Initialise a single‑node Docker Swarm and create an overlay network.
-* Deploy the Dokploy service and a Traefik reverse proxy as Swarm services.
-* Set up Windows `portproxy` rules to forward ports 80, 443 and 3000 from the
-  Windows host to the WSL IP address.
-* Open firewall rules on the Windows host to allow inbound traffic on the
-  configured ports.
+* Verify administrator privileges, ensure WSL/systemd/Docker are available and
+  guard the Windows host ports (80/443/3000 by default) before creating
+  `portproxy` bindings.
+* Start Docker via `systemd`, wait for the daemon to be ready and initialise a
+  single-node Docker Swarm.
+* Create an overlay network, persistent Postgres volume and Docker secret for a
+  randomly generated Postgres password.
+* Generate `/etc/dokploy/dokploy.env` (mode `640`) with a secret-backed
+  `DATABASE_URL` and write `/etc/dokploy/traefik/traefik.yml` (mode `640`).
+* Deploy Postgres, Dokploy and Traefik as Swarm services with health checks,
+  Traefik labels scoped to your configured hostnames and optional TLS via ACME
+  DNS challenges.
+* Create Windows firewall rules, `portproxy` forwards (80/443/3000 by default)
+  and a scheduled task that rebinds the proxies on boot or logon so that WSL IP
+  changes are handled automatically.
+* Validate that listeners are active inside WSL after deployment.
 
 Run the installer:
 
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force
-./scripts/install.ps1
+./scripts/install.ps1 -RouterHosts dokploy.local
 ```
 
-After installation completes you can access the Dokploy admin UI at
-`http://localhost:3000` on your Windows machine.  The public HTTP and HTTPS
-endpoints are forwarded to the WSL instance via portproxy.
+The `-RouterHosts` parameter accepts one or more hostnames used by Traefik for
+routing (e.g. `-RouterHosts dokploy.local,apps.example.com`).  Ports can be
+customised with `-HttpPort`/`-HttpsPort`.
+
+### Enabling TLS with ACME DNS-01
+
+To request certificates automatically, enable TLS and provide the ACME
+configuration:
+
+```powershell
+./scripts/install.ps1 -RouterHosts dokploy.example.com -EnableTls -AcmeEmail you@example.com -AcmeDnsProvider cloudflare
+```
+
+The script creates `/etc/dokploy/traefik/acme.json` (mode `600`), configures
+Traefik’s DNS-01 resolver and redirects HTTP to HTTPS.  Supply the provider’s
+credentials via environment variables or files according to Traefik’s DNS
+provider documentation before running the installer.
 
 ## Updating Dokploy
 
-To update Dokploy to the latest image run the script with `-Update`:
+To update Dokploy to the latest image run the script with `-Update` (the same
+routing/TLS parameters apply):
 
 ```powershell
-./scripts/install.ps1 -Update
+./scripts/install.ps1 -Update -RouterHosts dokploy.local
 ```
 
-This will pull the latest image and update the running service.  Port
-forwarding rules are refreshed automatically.
+This will refresh images, secrets, Traefik configuration, health checks and
+port-forwarding rules.  The scheduled task is re-registered to ensure future
+WSL IP changes are handled.
 
 ## Considerations
 
-* The WSL IP address can change when you restart the distribution or reboot
-  Windows.  The script re‑applies portproxy rules based on the current IP.
-* This setup uses a basic Traefik configuration.  For production use you
-  should supply your own `traefik.yml` and enable ACME certificates.
-* Windows Server does not officially support Docker Desktop; running Docker
-  inside WSL is a workaround that is suitable for development and testing.
+* The scheduled task re-applies `portproxy` rules on startup/logon, but you can
+  trigger it manually with `./scripts/install.ps1 -Rebind` if required.
+* If another service is already listening on your chosen HTTP/HTTPS/UI ports,
+  the installer fails fast so you can release the port or adjust the bindings.
+* For production scenarios you should secure Traefik further (mTLS, access
+  control, secret management) and consider publishing Dokploy behind an
+  additional reverse proxy such as IIS if it already runs on the host.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -6,88 +6,373 @@
 
 param(
     [switch]$Update,
+    [switch]$Rebind,
     [string]$Distro = "Ubuntu-22.04",
-    [int]$HttpPort = 8080,
-    [int]$HttpsPort = 8443
+    [int]$HttpPort = 80,
+    [int]$HttpsPort = 443,
+    [string[]]$RouterHosts = @("dokploy.local"),
+    [switch]$EnableTls,
+    [string]$AcmeEmail,
+    [string]$AcmeDnsProvider
 )
 
 function Get-WslIp {
     # Determine the IPv4 address of eth0 inside the WSL distribution.
-    $ip = wsl -d $Distro -e sh -lc "ip -4 addr show eth0 | awk '/inet /{print \$2}' | cut -d/ -f1" 2>$null
+    $ip = wsl -d $Distro -e sh -lc "ip -4 addr show eth0 | awk '/inet /{print \\\$2}' | cut -d/ -f1" 2>$null
     return $ip.Trim()
+}
+
+function Invoke-WslRootCommand {
+    param([string]$Command)
+    wsl -d $Distro -u root -e sh -lc $Command
+}
+
+function Invoke-WslRootCommandChecked {
+    param([string]$Command)
+    $result = Invoke-WslRootCommand $Command
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "WSL command failed ($Command) with exit code $exitCode"
+    }
+    return $result
+}
+
+function New-RandomPassword {
+    param([int]$Length = 32)
+    $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+    -join ((1..$Length) | ForEach-Object { $chars[(Get-Random -Maximum $chars.Length)] })
+}
+
+function Test-PortFree {
+    param([int]$Port)
+    $connection = Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue
+    if ($connection) {
+        $portproxyConfig = netsh interface portproxy show v4tov4 2>$null
+        $isPortProxy = $false
+        if ($portproxyConfig) {
+            $pattern = "\s+0\.0\.0\.0\s+$Port\s+"
+            $isPortProxy = [bool]([regex]::Match($portproxyConfig, $pattern).Success)
+        }
+        if (-not $isPortProxy) {
+            throw "Windows port $Port is in use"
+        }
+    }
 }
 
 function Configure-PortProxy {
     param([int[]]$Ports)
     $wslIp = Get-WslIp
     foreach ($p in $Ports) {
-        # Remove any existing proxy for the port
         netsh interface portproxy delete v4tov4 listenport=$p protocol=tcp 2>$null | Out-Null
-        # Create portproxy from Windows to WSL
         netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=$p connectaddress=$wslIp connectport=$p protocol=tcp | Out-Null
-        # Open firewall rule
         New-NetFirewallRule -DisplayName "Dokploy-$p" -Direction Inbound -Action Allow -Protocol TCP -LocalPort $p -ErrorAction SilentlyContinue | Out-Null
     }
 }
 
+function Ensure-TraefikConfig {
+    param([switch]$TlsEnabled)
+    $traefikDir = "/etc/dokploy/traefik"
+    Invoke-WslRootCommandChecked "install -d -m 750 $traefikDir"
+
+    $configBuilder = New-Object System.Text.StringBuilder
+    $null = $configBuilder.AppendLine("entryPoints:")
+    $null = $configBuilder.AppendLine("  web:")
+    $null = $configBuilder.AppendLine("    address: \":$HttpPort\"")
+    if ($TlsEnabled) {
+        $null = $configBuilder.AppendLine("    http:")
+        $null = $configBuilder.AppendLine("      redirections:")
+        $null = $configBuilder.AppendLine("        entryPoint:")
+        $null = $configBuilder.AppendLine("          to: websecure")
+        $null = $configBuilder.AppendLine("          scheme: https")
+    }
+    $null = $configBuilder.AppendLine("  websecure:")
+    $null = $configBuilder.AppendLine("    address: \":$HttpsPort\"")
+
+    $null = $configBuilder.AppendLine()
+    $null = $configBuilder.AppendLine("providers:")
+    $null = $configBuilder.AppendLine("  docker:")
+    $null = $configBuilder.AppendLine("    swarmMode: true")
+    $null = $configBuilder.AppendLine("    watch: true")
+    $null = $configBuilder.AppendLine("    endpoint: \"unix:///var/run/docker.sock\"")
+    $null = $configBuilder.AppendLine("    exposedByDefault: false")
+
+    if ($TlsEnabled) {
+        if (-not $AcmeEmail -or -not $AcmeDnsProvider) {
+            throw "TLS is enabled but ACME email or DNS provider is missing"
+        }
+        $null = $configBuilder.AppendLine()
+        $null = $configBuilder.AppendLine("certificatesResolvers:")
+        $null = $configBuilder.AppendLine("  dns01:")
+        $null = $configBuilder.AppendLine("    acme:")
+        $null = $configBuilder.AppendLine("      email: $AcmeEmail")
+        $null = $configBuilder.AppendLine("      storage: /etc/dokploy/traefik/acme.json")
+        $null = $configBuilder.AppendLine("      dnsChallenge:")
+        $null = $configBuilder.AppendLine("        provider: $AcmeDnsProvider")
+
+        Invoke-WslRootCommandChecked "install -d -m 750 $traefikDir && touch $traefikDir/acme.json && chmod 600 $traefikDir/acme.json"
+    }
+
+    $traefikConfig = $configBuilder.ToString()
+    $traefikBase64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($traefikConfig))
+    $escapedBase64 = $traefikBase64.Replace("'", "'\''")
+    Invoke-WslRootCommandChecked "env CFG_B64='$escapedBase64' sh -lc 'printf \"%s\" \"\$CFG_B64\" | base64 -d > $traefikDir/traefik.yml && chmod 640 $traefikDir/traefik.yml'"
+}
+
+function Ensure-Secrets {
+    $secretsDir = "/etc/dokploy/secrets"
+    Invoke-WslRootCommandChecked "install -d -m 750 $secretsDir"
+
+    $existingBase64 = (wsl -d $Distro -u root -e sh -lc "if [ -f $secretsDir/postgres_password ]; then base64 -w0 $secretsDir/postgres_password; fi" 2>$null)
+    if ([string]::IsNullOrWhiteSpace($existingBase64)) {
+        $password = New-RandomPassword
+        $passwordBase64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($password))
+    } else {
+        $passwordBase64 = $existingBase64.Trim()
+        $passwordBytes = [Convert]::FromBase64String($passwordBase64)
+        $password = [Text.Encoding]::UTF8.GetString($passwordBytes)
+    }
+
+    $escapedPassword = $passwordBase64.Replace("'", "'\''")
+
+    Invoke-WslRootCommandChecked "env PW_B64='$escapedPassword' sh -lc 'umask 0177; printf \"%s\" \"\$PW_B64\" | base64 -d > $secretsDir/postgres_password'"
+    Invoke-WslRootCommand "docker secret rm dokploy_postgres_password >/dev/null 2>&1 || true" | Out-Null
+    Invoke-WslRootCommandChecked "env PW_B64='$escapedPassword' sh -lc 'printf \"%s\" \"\$PW_B64\" | base64 -d | docker secret create dokploy_postgres_password -'"
+
+    return $password
+}
+
+function Ensure-DokployEnvFile {
+    param([string]$PostgresPassword)
+
+    $escapedPassword = [System.Uri]::EscapeDataString($PostgresPassword)
+    $databaseUrl = "postgresql://dokploy:$escapedPassword@dokploy-postgres:5432/dokploy"
+    $envContent = "DATABASE_URL=$databaseUrl`nTZ=UTC`n"
+    $envBase64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($envContent))
+    $escapedEnvBase64 = $envBase64.Replace("'", "'\''")
+    Invoke-WslRootCommandChecked "env ENV_B64='$escapedEnvBase64' sh -lc 'install -d -m 750 /etc/dokploy && umask 0027; printf \"%s\" \"\$ENV_B64\" | base64 -d > /etc/dokploy/dokploy.env'"
+
+    return $databaseUrl
+}
+
+function Test-WslPorts {
+    param([int[]]$Ports)
+    $pattern = ($Ports | ForEach-Object { ":$_" }) -join "|"
+    $output = wsl -d $Distro -e sh -lc "ss -ltnp | grep -E '($pattern)' || true" 2>$null
+    if ([string]::IsNullOrWhiteSpace($output)) {
+        Write-Warning "No listeners detected inside WSL for ports: $($Ports -join ', ')"
+    } else {
+        Write-Host "WSL listeners:" -ForegroundColor Cyan
+        $output.Trim().Split("`n") | ForEach-Object { Write-Host "  $_" }
+    }
+}
+
+function Assert-Systemd {
+    Invoke-WslRootCommand "test -d /run/systemd/system" | Out-Null
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "WSL distro lacks systemd. Set [boot] systemd=true and restart WSL."
+    }
+}
+
 function Start-Docker {
-    # Start Docker inside WSL.  Works for distributions with systemd.
-    wsl -d $Distro -e sh -lc "systemctl is-active docker || (sudo systemctl enable docker && sudo systemctl start docker)" | Out-Null
+    Invoke-WslRootCommand "systemctl is-active docker || (systemctl enable docker && systemctl start docker)" | Out-Null
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        throw "Failed to start Docker via systemd"
+    }
+}
+
+function Wait-ForDocker {
+    Invoke-WslRootCommandChecked "until docker info >/dev/null 2>&1; do sleep 1; done"
+}
+
+function Get-RouterRule {
+    if (-not $RouterHosts -or $RouterHosts.Count -eq 0) {
+        throw "RouterHosts must contain at least one host name"
+    }
+    $backtick = [char]0x60
+    $hostRules = $RouterHosts | ForEach-Object { "Host($backtick$_$backtick)" }
+    return [string]::Join(" || ", $hostRules)
+}
+
+function Deploy-PostgresService {
+    $postgresCommand = @(
+        "docker service create",
+        "--name dokploy-postgres",
+        "--replicas 1",
+        "--network dokploy-network",
+        "--secret source=dokploy_postgres_password,target=dokploy_postgres_password",
+        "--mount type=volume,source=dokploy-postgres,target=/var/lib/postgresql/data",
+        "--constraint node.role==manager",
+        "--env POSTGRES_DB=dokploy",
+        "--env POSTGRES_USER=dokploy",
+        "--env POSTGRES_PASSWORD_FILE=/run/secrets/dokploy_postgres_password",
+        "--health-cmd 'pg_isready -U dokploy -h 127.0.0.1 -d dokploy'",
+        "--health-interval 10s",
+        "--health-retries 5",
+        "postgres:16-alpine"
+    ) -join ' '
+    Invoke-WslRootCommandChecked $postgresCommand | Out-Null
+}
+
+function Deploy-DokployService {
+    param([string]$RouterRule)
+
+    $dokployCommandArgs = [System.Collections.Generic.List[string]]::new()
+    $dokployCommandArgs.Add("docker service create") | Out-Null
+    $dokployCommandArgs.Add("--name dokploy") | Out-Null
+    $dokployCommandArgs.Add("--replicas 1") | Out-Null
+    $dokployCommandArgs.Add("--network dokploy-network") | Out-Null
+    $dokployCommandArgs.Add("--mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock") | Out-Null
+    $dokployCommandArgs.Add("--secret source=dokploy_postgres_password,target=dokploy_postgres_password") | Out-Null
+    $dokployCommandArgs.Add("--env-file /etc/dokploy/dokploy.env") | Out-Null
+    $dokployCommandArgs.Add("--publish published=3000,target=3000,mode=host") | Out-Null
+    $dokployCommandArgs.Add("--constraint node.role==manager") | Out-Null
+    $dokployCommandArgs.Add("--label traefik.enable=true") | Out-Null
+    $dokployCommandArgs.Add("--label 'traefik.http.routers.dokploy.rule=$RouterRule'") | Out-Null
+    $dokployCommandArgs.Add("--label traefik.http.routers.dokploy.entrypoints=web,websecure") | Out-Null
+    $dokployCommandArgs.Add("--label traefik.http.services.dokploy.loadbalancer.server.port=3000") | Out-Null
+    if ($EnableTls) {
+        $dokployCommandArgs.Add("--label traefik.http.routers.dokploy.tls=true") | Out-Null
+        $dokployCommandArgs.Add("--label traefik.http.routers.dokploy.tls.certresolver=dns01") | Out-Null
+    }
+    $dokployCommandArgs.Add("--health-cmd 'wget -qO- http://127.0.0.1:3000/healthz || exit 1'") | Out-Null
+    $dokployCommandArgs.Add("--health-interval 10s") | Out-Null
+    $dokployCommandArgs.Add("--health-retries 12") | Out-Null
+    $dokployCommandArgs.Add("dokploy/dokploy:latest") | Out-Null
+    $dokployCommand = [string]::Join(' ', $dokployCommandArgs)
+    Invoke-WslRootCommandChecked $dokployCommand | Out-Null
+}
+
+function Deploy-TraefikService {
+    $traefikCommandArgs = [System.Collections.Generic.List[string]]::new()
+    $traefikCommandArgs.Add("docker service create") | Out-Null
+    $traefikCommandArgs.Add("--name dokploy-traefik") | Out-Null
+    $traefikCommandArgs.Add("--network dokploy-network") | Out-Null
+    $traefikCommandArgs.Add("--constraint node.role==manager") | Out-Null
+    $traefikCommandArgs.Add("--mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock") | Out-Null
+    $traefikCommandArgs.Add("--mount type=bind,source=/etc/dokploy/traefik/traefik.yml,target=/etc/traefik/traefik.yml,readonly") | Out-Null
+    if ($EnableTls) {
+        $traefikCommandArgs.Add("--mount type=bind,source=/etc/dokploy/traefik/acme.json,target=/etc/traefik/acme.json") | Out-Null
+    }
+    $traefikCommandArgs.Add("--publish published=$HttpPort,target=80,mode=host") | Out-Null
+    $traefikCommandArgs.Add("--publish published=$HttpsPort,target=443,mode=host") | Out-Null
+    $traefikCommandArgs.Add("traefik:v3.5.0") | Out-Null
+    $traefikCommand = [string]::Join(' ', $traefikCommandArgs)
+    Invoke-WslRootCommandChecked $traefikCommand | Out-Null
+}
+
+function Wait-ForServiceRemoval {
+    param([string[]]$Names)
+    foreach ($name in $Names) {
+        Invoke-WslRootCommandChecked "while docker service inspect $name >/dev/null 2>&1; do sleep 1; done"
+    }
+}
+
+function Register-PortProxyTask {
+    $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -WindowStyle Hidden -File `"$PSCommandPath`" -Rebind"
+    $triggers = @(New-ScheduledTaskTrigger -AtStartup, New-ScheduledTaskTrigger -AtLogOn)
+    Register-ScheduledTask -TaskName "Dokploy-RebindPorts" -Action $action -Trigger $triggers -RunLevel Highest -Force | Out-Null
+}
+
+if ($Rebind) {
+    Configure-PortProxy -Ports @($HttpPort,$HttpsPort,3000)
+    exit
 }
 
 function Install-Dokploy {
     Write-Host "Starting Dokploy installation..." -ForegroundColor Green
 
-    # Require admin
     $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
     if (-not $isAdmin) {
         Write-Error "This script must be run as Administrator."; return
     }
 
-    # Verify WSL
     try {
         wsl --status 2>$null | Out-Null
     } catch {
         Write-Error "WSL2 is not installed. Please install WSL2 and a Linux distribution."; return
     }
 
-    # Verify Docker command inside WSL
+    Assert-Systemd
+
     $dockerExists = wsl -d $Distro -e sh -lc "command -v docker" 2>$null
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Docker is not installed in WSL. Install Docker in your $Distro distribution."; return
     }
 
-    # Ensure Docker is running
+    Test-PortFree $HttpPort
+    Test-PortFree $HttpsPort
+    Test-PortFree 3000
+
     Start-Docker
+    Wait-ForDocker
 
-    # Initialise Swarm (optional) and network
-    wsl -d $Distro -e sh -lc "docker swarm leave --force 2>/dev/null || true" | Out-Null
+    Ensure-TraefikConfig -TlsEnabled:$EnableTls
+
+    Invoke-WslRootCommand "docker service rm dokploy dokploy-traefik dokploy-postgres >/dev/null 2>&1 || true" | Out-Null
+    Invoke-WslRootCommand "docker stack rm dokploy >/dev/null 2>&1 || true" | Out-Null
+    Wait-ForServiceRemoval -Names @("dokploy","dokploy-traefik","dokploy-postgres")
+    Invoke-WslRootCommand "docker swarm leave --force >/dev/null 2>&1 || true" | Out-Null
+
     $wslIp = Get-WslIp
-    wsl -d $Distro -e sh -lc "docker swarm init --advertise-addr $wslIp || true" | Out-Null
-    wsl -d $Distro -e sh -lc "docker network create --driver overlay --attachable dokploy-network || true" | Out-Null
+    Invoke-WslRootCommandChecked "docker swarm init --advertise-addr $wslIp >/dev/null 2>&1"
+    Wait-ForDocker
 
-    # Pull images
-    wsl -d $Distro -e sh -lc "docker pull dokploy/dokploy:latest" | Out-Null
-    wsl -d $Distro -e sh -lc "docker pull traefik:v3.5.0" | Out-Null
+    Invoke-WslRootCommand "docker network create --driver overlay --attachable dokploy-network >/dev/null 2>&1 || true" | Out-Null
+    Invoke-WslRootCommand "docker volume create dokploy-postgres >/dev/null 2>&1 || true" | Out-Null
 
-    # Deploy Dokploy service
-    wsl -d $Distro -e sh -lc "docker service create --name dokploy --replicas 1 --network dokploy-network --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock --publish published=3000,target=3000,mode=host dokploy/dokploy:latest" | Out-Null
+    $postgresPassword = Ensure-Secrets
+    Ensure-DokployEnvFile -PostgresPassword $postgresPassword | Out-Null
 
-    # Deploy Traefik as a service on ports 80/443 inside WSL
-    wsl -d $Distro -e sh -lc "docker service create --name dokploy-traefik --network dokploy-network --publish published=80,target=80,mode=host --publish published=443,target=443,mode=host -v /var/run/docker.sock:/var/run/docker.sock traefik:v3.5.0 --providers.docker.swarmMode=true --entrypoints.web.address=\":80\" --entrypoints.websecure.address=\":443\"" | Out-Null
+    Invoke-WslRootCommandChecked "docker pull dokploy/dokploy:latest"
+    Invoke-WslRootCommandChecked "docker pull traefik:v3.5.0"
+    Invoke-WslRootCommandChecked "docker pull postgres:16-alpine"
 
-    # Expose ports to Windows via portproxy
+    $routerRule = Get-RouterRule
+
+    Deploy-PostgresService
+    Deploy-DokployService -RouterRule $routerRule
+    Deploy-TraefikService
+
     Configure-PortProxy -Ports @($HttpPort,$HttpsPort,3000)
+    Register-PortProxyTask
+    Test-WslPorts -Ports @($HttpPort,$HttpsPort,3000)
 
-    Write-Host "Dokploy has been deployed.  Ports $HttpPort (HTTP), $HttpsPort (HTTPS) and 3000 (Admin UI) are forwarded to WSL." -ForegroundColor Green
+    Write-Host "Dokploy has been deployed. Ports $HttpPort (HTTP), $HttpsPort (HTTPS) and 3000 (Admin UI) are forwarded to WSL." -ForegroundColor Green
 }
 
 function Update-Dokploy {
     Write-Host "Updating Dokploy..." -ForegroundColor Green
-    wsl -d $Distro -e sh -lc "docker pull dokploy/dokploy:latest" | Out-Null
-    wsl -d $Distro -e sh -lc "docker service update --image dokploy/dokploy:latest dokploy" | Out-Null
-    Write-Host "Dokploy updated." -ForegroundColor Green
+
+    Assert-Systemd
+
+    Start-Docker
+    Wait-ForDocker
+
+    $postgresPassword = Ensure-Secrets
+    Ensure-DokployEnvFile -PostgresPassword $postgresPassword | Out-Null
+    Ensure-TraefikConfig -TlsEnabled:$EnableTls
+
+    Invoke-WslRootCommandChecked "docker pull dokploy/dokploy:latest"
+    Invoke-WslRootCommandChecked "docker pull traefik:v3.5.0"
+    Invoke-WslRootCommandChecked "docker pull postgres:16-alpine"
+
+    $routerRule = Get-RouterRule
+
+    Invoke-WslRootCommand "docker service rm dokploy dokploy-traefik >/dev/null 2>&1 || true" | Out-Null
+    Wait-ForServiceRemoval -Names @("dokploy","dokploy-traefik")
+
+    Deploy-DokployService -RouterRule $routerRule
+    Deploy-TraefikService
+
+    Invoke-WslRootCommandChecked "docker service update --image postgres:16-alpine dokploy-postgres" | Out-Null
+
     Configure-PortProxy -Ports @($HttpPort,$HttpsPort,3000)
+    Register-PortProxyTask
+    Test-WslPorts -Ports @($HttpPort,$HttpsPort,3000)
+
+    Write-Host "Dokploy updated." -ForegroundColor Green
 }
 
 if ($Update) { Update-Dokploy } else { Install-Dokploy }


### PR DESCRIPTION
## Summary
- guard Windows ports, verify systemd, and enforce checked WSL command execution before deploying the Dokploy swarm stack
- add reusable helpers to redeploy services with health checks, host-scoped Traefik routing, optional ACME DNS TLS, and a scheduled task that rebinds portproxy rules
- update the Windows/WSL2 guide to document the new parameters, TLS workflow, and automated port rebind behaviour

## Testing
- not run (PowerShell script)


------
https://chatgpt.com/codex/tasks/task_e_68e5cf348c488323a1a6941a3c415332